### PR TITLE
first try for multi-stage build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+Dockerfile
+conf/
+.git/

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,8 @@ WORKDIR /vroom-express
 
 RUN apt-get update > /dev/null && \
     apt-get install -y --no-install-recommends \
-      libssl-dev \
-    	libboost-all-dev \
+      libssl1.1 \
+    	libboost-system1.67.0 \
       > /dev/null && \
     rm -rf /var/lib/apt/lists/* && \
     # Install vroom-express

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     volumes:
       - ./vroom_conf/:/conf
     environment:
-      - VROOM_ROUTER=osrm  # or libosrm, ors
+      - VROOM_ROUTER=osrm  # ors
     depends_on:
       - ors-app
   # Example for OpenRouteService


### PR DESCRIPTION
Fixes #3 

Does now a multi-stage build for the final image:
1. build stage: installs all dependencies to build vroom and clones both repos
2. run stage: only installs needed linked libs, copies vroom binary and vroom-express repo from build stage, and installs (and runs) the node project

However, even now the final image size is close to 1 GB. The `libboost-all-dev` libs are HUGE! If I leave that out of the image, the final size is only 215 MB, even with `libssl-dev`!

So, I'm wondering @jcoupey, can we do it similar to `osrm` and only install the boost components vroom needs to run? They do this in their [Dockerfile](https://hub.docker.com/r/osrm/osrm-backend/dockerfile):

```
apt-get install -y --no-install-recommends libboost-program-options1.62.0 libboost-regex1.62.0 \
        libboost-date-time1.62.0 libboost-chrono1.62.0 libboost-filesystem1.62.0 \
        libboost-iostreams1.62.0 libboost-thread1.62.0 expat liblua5.2-0 libtbb2 &&\
```

Or would that entail a change in the `makefile`? I'm hopeless with C++ builds..