### PR TITLE
release v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [v1.7.0] - 2020-07-09
 
-## Added
+### Added
 
 - License file to make it clear the project is under BSD-2-Clause (#13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-## Changed
+## [v1.7.0] - 2020-07-09
+
+### Changed
 
 - `docker-compose` ORS setup to use `latest` image until new ORS release, 2020.05.26
+- Support for VROOM release 1.7.0 and vroom-express release 0.7.0
 
 ## [v1.6.0] - 2020-05-03
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,10 @@ RUN echo "Updating apt-get and installing dependencies..." && \
   build-essential \
 	g++ \
   libssl-dev \
-	libboost-all-dev \
+	libasio-dev \
 	pkg-config
 
-ARG VROOM_RELEASE=v1.6.0
+ARG VROOM_RELEASE=v1.7.0
 
 RUN echo "Cloning and installing vroom release ${VROOM_RELEASE}..." && \
     git clone https://github.com/VROOM-Project/vroom.git && \
@@ -23,7 +23,7 @@ RUN echo "Cloning and installing vroom release ${VROOM_RELEASE}..." && \
     cd /
 
 # TODO: change to release version again
-ARG VROOM_EXPRESS_RELEASE=v0.6.0
+ARG VROOM_EXPRESS_RELEASE=v0.7.0
 
 RUN echo "Cloning and installing vroom-express release ${VROOM_EXPRESS_RELEASE}..." && \
     git clone https://github.com/VROOM-Project/vroom-express.git && \
@@ -40,7 +40,6 @@ WORKDIR /vroom-express
 RUN apt-get update > /dev/null && \
     apt-get install -y --no-install-recommends \
       libssl1.1 \
-    	libboost-system1.67.0 \
       curl \
       > /dev/null && \
     rm -rf /var/lib/apt/lists/* && \

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ docker run -dt --name vroom \
     --net host \  # or set the container name as host in config.yml and use --port 3000:3000 instead, see below
     -v $PWD/conf:/conf \ # mapped volume for config & log
     -e VROOM_ROUTER=ors \ # routing layer: osrm or ors
-    vroomvrp/vroom-docker:v1.6.0
+    vroomvrp/vroom-docker:v1.7.0
 ```
 
 If you want to build the image yourself, run a
 
-`docker build -t vroomvrp/vroom-docker:v1.6.0 --build-arg VROOM_RELEASE=v1.6.0 --build-arg VROOM_EXPRESS_RELEASE=v0.5.0 .`
+`docker build -t vroomvrp/vroom-docker:v1.6.0 --build-arg VROOM_RELEASE=v1.7.0 --build-arg VROOM_EXPRESS_RELEASE=v0.7.0 .`
 
 > **Note**, you should have access to a self-hosted instance of OSRM or OpenRouteService for the routing server, see e.g. [`docker-compose.yml`](docker-compose.yml) for an example.
 
@@ -43,8 +43,8 @@ Add a `-v $PWD/conf:/conf` to your `docker run` command.
 
 If you prefer to build the image from source, there are 2 build arguments:
 
-- `VROOM_RELEASE`: specifies VROOM's git [branch](https://github.com/VROOM-Project/vroom/branches), [commit hash](https://github.com/VROOM-Project/vroom/commits/master) or [release](https://github.com/VROOM-Project/vroom/releases) (e.g. `v1.6.0`) to install in the container
-- `VROOM_EXPRESS_RELEASE`: specifies `vroom-express`'s git [branch](https://github.com/VROOM-Project/vroom-express/branches), [commit hash](https://github.com/VROOM-Project/vroom-express/commits/master) or [release](https://github.com/VROOM-Project/vroom-express/releases) (e.g. `v0.6.0`) to install in the container
+- `VROOM_RELEASE`: specifies VROOM's git [branch](https://github.com/VROOM-Project/vroom/branches), [commit hash](https://github.com/VROOM-Project/vroom/commits/master) or [release](https://github.com/VROOM-Project/vroom/releases) (e.g. `v1.7.0`) to install in the container
+- `VROOM_EXPRESS_RELEASE`: specifies `vroom-express`'s git [branch](https://github.com/VROOM-Project/vroom-express/branches), [commit hash](https://github.com/VROOM-Project/vroom-express/commits/master) or [release](https://github.com/VROOM-Project/vroom-express/releases) (e.g. `v0.7.0`) to install in the container
 
 > **Note**, not all versions are compatible with each other
 


### PR DESCRIPTION
fixes #16, fixes #15 

Support for vroom v1.7.0 and vroom-express v0.7.0.

The feeling when dropping libboost-all-dev :candy: 

Oddities:
- the image without boost is actually bigger than before.. (EDIT: 216 MB vs 215 MB, so nothing..) The released image actually only had the `libboost-system` dep and I guess including libasio outweighs. But the builds are sooo much faster without boost, still really good.
- Testing this release I didn't have an ORS instance on 8080 and vroom still gave a positive response (with 0 durations)! What I did have on port 8080 was a wordpress container, but couldn't figure out how to let wordpress calculate matrices.. Would've expected an error, though not a big deal.

Once approved I'll push the release tag @jcoupey so Dockerhub picks it up.