### PR TITLE
Fix OSRM image name on Compose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - PBF file needs to be set by user in ORS instance ([#22](https://github.com/VROOM-Project/vroom-docker/issues/22))
 - updated a deprecated java option for ORS ([#22](https://github.com/VROOM-Project/vroom-docker/issues/22))
+- OSRM docker image had the wrong name (#23)
 
 ## [v1.8.0] - 2020-09-30
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - "CATALINA_OPTS=-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=9001 -Dcom.sun.management.jmxremote.rmi.port=9001 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=localhost"
   # Example for OSRM
   osrm:
-    image: osrm-data/osrm-backend
+    image: osrm/osrm-backend
     container_name: osrm
     restart: always
     ports:


### PR DESCRIPTION
OSRM seems to have been moved to https://hub.docker.com/r/osrm/osrm-backend