### PR TITLE
Build multiarch image

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,6 +1,6 @@
 # only builds and tests on tag pushes and PRs to master
 # only pushes on tag pushes
-name: build & test
+name: Build & test docker image
 on:
   push:
     branches:
@@ -21,15 +21,25 @@ on:
 
 jobs:
   build_test_publish:
+    strategy:
+        matrix:
+          platform: [linux/arm64, linux/amd64]
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
       - name: Build Image
         run: |
           echo "Building image vroomvrp/vroom-docker:latest"
-          docker build -t vroomvrp/vroom-docker:latest .
+          docker buildx build --load --platform ${{ matrix.platform }} --tag vroomvrp/vroom-docker:latest .
 
       - name: Test tagged image
-        run : sudo /bin/bash -c "./tests/test.sh vroomvrp/vroom-docker:latest"
+        run : |
+          sudo /bin/bash -c "./tests/test.sh vroomvrp/vroom-docker:latest"      

--- a/.github/workflows/test_publish.yml
+++ b/.github/workflows/test_publish.yml
@@ -1,6 +1,6 @@
 # only builds and tests on tag pushes and PRs to master
 # only pushes on tag pushes
-name: test & publish
+name: Release docker image
 on:
   push:
     branches-ignore:
@@ -18,25 +18,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Extract tag name
         id: tag
         run: echo ::set-output name=TAG::${GITHUB_REF#refs/tags/}
-
-      - name: Build tagged Image
-        run: |
-          echo "Building image vroomvrp/vroom-docker:${{ steps.tag.outputs.TAG }}"
-          docker build -t vroomvrp/vroom-docker:${{ steps.tag.outputs.TAG }} .
-
-      - name: Test tagged image
-        run : sudo /bin/bash -c "./tests/test.sh vroomvrp/vroom-docker:${{ steps.tag.outputs.TAG }}"
+      
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Push image
-        run: docker push vroomvrp/vroom-docker:${{ steps.tag.outputs.TAG }}
+      - name: Build and push tagged Image
+        run: |
+          echo "Building image vroomvrp/vroom-docker:${{ steps.tag.outputs.TAG }}"
+          docker buildx build --push --platform linux/amd64,linux/arm64 --tag vroomvrp/vroom-docker:${{ steps.tag.outputs.TAG }} .


### PR DESCRIPTION
This PR enables building [multiarch](https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/) docker images for amd64 and arm64.

This change will enable compatibility with Apple M1/M2 and [Amazon Graviton](https://aws.amazon.com/ec2/graviton/) processors