### PR TITLE
migrate to github docker registry

### DIFF
--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'nn-ghcr'
     paths-ignore:
       - '.gitignore'
       - 'docker-compose.yml'
@@ -38,6 +39,6 @@ jobs:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: ghcr.io/VROOM-Project/vroom-docker:latest
+          tags: ghcr.io/{{ github.repository }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max   

--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -39,6 +39,6 @@ jobs:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: ghcr.io/${{ github.repository }}:latest
+          tags: ghcr.io/vroom-project/vroom-docker:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max   

--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -39,6 +39,6 @@ jobs:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: ghcr.io/{{ github.repository }}:latest
+          tags: ghcr.io/${{ github.repository }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max   

--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -1,6 +1,9 @@
-# only builds and tests on master pushes
+# builds and pushes image on master pushes 
+# and every 1st and 15th of the month
 name: Master push
 on:
+  schedule:
+    - cron: '0 0 1,15 * *'
   push:
     branches:
       - 'master'
@@ -12,26 +15,29 @@ on:
 
 jobs:
   build_test_publish:
-    strategy:
-        matrix:
-          arch: [linux/arm64, linux/amd64]
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
-
+      
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
-      - name: Build Image
-        run: |
-          echo "Building image vroomvrp/vroom-docker:latest"
-          docker buildx build --load --platform ${{ matrix.arch }} --tag vroomvrp/vroom-docker:latest .
-
-      - name: Test tagged image
-        if: matrix.arch == 'linux/amd64'
-        run : |
-          sudo /bin/bash -c "./tests/test.sh vroomvrp/vroom-docker:latest"      
+      - name: Log in to GitHub Docker Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ghcr.io/VROOM-Project/vroom-docker:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max   

--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - 'master'
-      - 'nn-ghcr'
     paths-ignore:
       - '.gitignore'
       - 'docker-compose.yml'

--- a/.github/workflows/publish_tags.yml
+++ b/.github/workflows/publish_tags.yml
@@ -41,6 +41,6 @@ jobs:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: ghcr.io/${{ github.repository }}:${{ steps.tag.outputs.TAG }}"
+          tags: ghcr.io/vroom-project/vroom-docker:${{ steps.tag.outputs.TAG }}"
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/publish_tags.yml
+++ b/.github/workflows/publish_tags.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: vroom-express tag
         id: vroom_express_tag
-        run: curl  "https://api.github.com/repos/VROOM-Project/vroom/tags" | jq -r '.[0].name' >> GITHUB_OUTPUT
+        run: curl --silent "https://api.github.com/repos/VROOM-Project/vroom/tags" | jq -r '.[0].name' >> GITHUB_OUTPUT
       
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/publish_tags.yml
+++ b/.github/workflows/publish_tags.yml
@@ -41,6 +41,6 @@ jobs:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: ghcr.io/VROOM-Project/vroom-docker:${{ steps.tag.outputs.TAG }}"
+          tags: ghcr.io/${{ github.repository }}:${{ steps.tag.outputs.TAG }}"
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/publish_tags.yml
+++ b/.github/workflows/publish_tags.yml
@@ -19,9 +19,13 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
-      - name: Extract tag name
-        id: tag
+      - name: vroom tag
+        id: vroom_tag
         run: echo ::set-output name=TAG::${GITHUB_REF#refs/tags/}
+
+      - name: vroom-express tag
+        id: vroom_express_tag
+        run: curl  "https://api.github.com/repos/VROOM-Project/vroom/tags" | jq -r '.[0].name' >> GITHUB_OUTPUT
       
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -40,7 +44,8 @@ jobs:
         with:
           context: .
           push: true
+          build-args: ["VROOM_RELEASE=${{ steps.tag.outputs.VROOM_TAG }}", "VROOM_EXPRESS_RELEASE=${{ steps.tag.outputs.VROOM_EXPRESS_TAG }}"]
           platforms: linux/amd64,linux/arm64
-          tags: ghcr.io/vroom-project/vroom-docker:${{ steps.tag.outputs.TAG }}"
+          tags: ghcr.io/vroom-project/vroom-docker:${{ steps.tag.outputs.VROOM_TAG }}"
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/publish_tags.yml
+++ b/.github/workflows/publish_tags.yml
@@ -17,25 +17,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Extract tag name
         id: tag
         run: echo ::set-output name=TAG::${GITHUB_REF#refs/tags/}
       
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+      - name: Log in to GitHub Docker Registry
+        uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Build and push tagged Image
-        run: |
-          echo "Building image vroomvrp/vroom-docker:${{ steps.tag.outputs.TAG }}"
-          docker buildx build --push --platform linux/amd64,linux/arm64 --tag vroomvrp/vroom-docker:${{ steps.tag.outputs.TAG }} .
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ghcr.io/VROOM-Project/vroom-docker:${{ steps.tag.outputs.TAG }}"
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,13 +18,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build Image on amd64
         run: |
-          echo "Building image vroomvrp/vroom-docker:latest"
-          docker build --tag vroomvrp/vroom-docker:latest .
+          echo "Building image VROOM-Project/vroom-docker:latest"
+          docker build --tag VROOM-Project/vroom-docker:latest .
 
       - name: Test tagged amd64 image
         run : |
-          sudo /bin/bash -c "./tests/test.sh vroomvrp/vroom-docker:latest"
+          sudo /bin/bash -c "./tests/test.sh VROOM-Project/vroom-docker:latest"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,9 +22,9 @@ jobs:
 
       - name: Build Image on amd64
         run: |
-          echo "Building image ghcr.io/${{ github.repository }}:latest"
-          docker build --tag ghcr.io/${{ github.repository }}:latest .
+          echo "Building image ghcr.io/vroom-project/vroom-docker:latest"
+          docker build --tag ghcr.io/vroom-project/vroom-docker:latest .
 
       - name: Test tagged amd64 image
         run : |
-          sudo /bin/bash -c "./tests/test.sh ghcr.io/${{ github.repository }}:latest"
+          sudo /bin/bash -c "./tests/test.sh ghcr.io/vroom-project/vroom-docker:latest"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,9 +22,9 @@ jobs:
 
       - name: Build Image on amd64
         run: |
-          echo "Building image VROOM-Project/vroom-docker:latest"
-          docker build --tag VROOM-Project/vroom-docker:latest .
+          echo "Building image ghcr.io/{{ github.repository }}:latest"
+          docker build --tag ghcr.io/{{ github.repository }}:latest .
 
       - name: Test tagged amd64 image
         run : |
-          sudo /bin/bash -c "./tests/test.sh VROOM-Project/vroom-docker:latest"
+          sudo /bin/bash -c "./tests/test.sh ghcr.io/{{ github.repository }}:latest"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,9 +22,9 @@ jobs:
 
       - name: Build Image on amd64
         run: |
-          echo "Building image ghcr.io/{{ github.repository }}:latest"
-          docker build --tag ghcr.io/{{ github.repository }}:latest .
+          echo "Building image ghcr.io/${{ github.repository }}:latest"
+          docker build --tag ghcr.io/${{ github.repository }}:latest .
 
       - name: Test tagged amd64 image
         run : |
-          sudo /bin/bash -c "./tests/test.sh ghcr.io/{{ github.repository }}:latest"
+          sudo /bin/bash -c "./tests/test.sh ghcr.io/${{ github.repository }}:latest"

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *conf/
+docker-compose.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+**Migrated to Github's container registry, e.g. ghcr.iovroom-project/vroom-docker:latest.**
+
 [Vroom Changelog Unreleased](https://github.com/VROOM-Project/vroom/blob/master/CHANGELOG.md#unreleased)
 [Vroom-express Changelog Unreleased](https://github.com/VROOM-Project/vroom-express/blob/master/CHANGELOG.md#unreleased)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,25 +13,21 @@ RUN echo "Updating apt-get and installing dependencies..." && \
   libglpk-dev \
 	pkg-config
 
-ARG VROOM_RELEASE=v1.14.0-rc.2
+ARG VROOM_RELEASE=master
 
 RUN echo "Cloning and installing vroom release ${VROOM_RELEASE}..." && \
-    git clone --branch $VROOM_RELEASE --recurse-submodules https://github.com/VROOM-Project/vroom.git && \
+    git clone --branch $VROOM_RELEASE --single-branch --recurse-submodules https://github.com/VROOM-Project/vroom.git && \
     cd vroom && \
     make -C /vroom/src -j$(nproc) && \
     cd /
-
-ARG VROOM_EXPRESS_RELEASE=v0.12.0
-
-RUN echo "Cloning and installing vroom-express release ${VROOM_EXPRESS_RELEASE}..." && \
-    git clone --branch $VROOM_EXPRESS_RELEASE https://github.com/VROOM-Project/vroom-express.git && \
-    cd vroom-express
 
 FROM node:20-bookworm-slim as runstage
 COPY --from=builder /vroom-express/. /vroom-express
 COPY --from=builder /vroom/bin/vroom /usr/local/bin
 
 WORKDIR /vroom-express
+
+ARG VROOM_EXPRESS_RELEASE=master
 
 RUN apt-get update > /dev/null && \
     apt-get install -y --no-install-recommends \
@@ -41,6 +37,7 @@ RUN apt-get update > /dev/null && \
       > /dev/null && \
     rm -rf /var/lib/apt/lists/* && \
     # Install vroom-express
+    git clone --branch $VROOM_EXPRESS_RELEASE --single-branch https://github.com/VROOM-Project/vroom-express.git && \
     npm config set loglevel error && \
     npm install && \
     # To share the config.yml & access.log file with the host

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,9 @@ RUN echo "Cloning and installing vroom release ${VROOM_RELEASE}..." && \
     cd /
 
 FROM node:20-bookworm-slim as runstage
-COPY --from=builder /vroom-express/. /vroom-express
 COPY --from=builder /vroom/bin/vroom /usr/local/bin
 
-WORKDIR /vroom-express
+WORKDIR /
 
 ARG VROOM_EXPRESS_RELEASE=master
 
@@ -38,6 +37,7 @@ RUN apt-get update > /dev/null && \
     rm -rf /var/lib/apt/lists/* && \
     # Install vroom-express
     git clone --branch $VROOM_EXPRESS_RELEASE --single-branch https://github.com/VROOM-Project/vroom-express.git && \
+    cd vroom-express && \
     npm config set loglevel error && \
     npm install && \
     # To share the config.yml & access.log file with the host
@@ -45,7 +45,7 @@ RUN apt-get update > /dev/null && \
 
 
 COPY ./docker-entrypoint.sh /docker-entrypoint.sh
-ENV VROOM_DOCKER=osrm \
+ENV VROOM_ROUTER=osrm \
     VROOM_LOG=/conf
 
 HEALTHCHECK --start-period=10s CMD curl --fail -s http://localhost:3000/health || exit 1

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ docker run -dt --name vroom \
     --net host \  # or set the container name as host in config.yml and use --port 3000:3000 instead, see below
     -v $PWD/conf:/conf \ # mapped volume for config & log
     -e VROOM_ROUTER=osrm \ # routing layer: osrm, valhalla or ors
-    ghcr.iovroom-project/vroom-docker:v1.13.0
+    ghcr.io/vroom-project/vroom-docker:v1.13.0
 ```
 
 If you want to build the image yourself, run a
 
-`docker build -t ghcr.iovroom-project/vroom-docker:v1.13.0 --build-arg VROOM_RELEASE=v1.13.0 --build-arg VROOM_EXPRESS_RELEASE=v0.11.0 .`
+`docker build -t ghcr.io/vroom-project/vroom-docker:v1.13.0 --build-arg VROOM_RELEASE=v1.13.0 --build-arg VROOM_EXPRESS_RELEASE=v0.11.0 .`
 
 > **Note**, you should have access to a self-hosted instance of OSRM, Valhalla or OpenRouteService for the routing server.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Master push](https://github.com/VROOM-Project/vroom-docker/actions/workflows/master_push.yml/badge.svg)](https://github.com/VROOM-Project/vroom-docker/actions/workflows/master_push.yml)
 
+**Note**, this repo is migrating to Github's container registry, releases from v1.14.0 on will not be published at hub.docker.com.
+
 This image includes all dependencies and projects needed to successfully run an instance of [`vroom-express`](https://github.com/VROOM-Project/vroom-express) on top of [`vroom`](https://github.com/VROOM-Project/vroom). Within 2 minutes you'll have a routing optimization engine running on your machine.
 
 ```bash
@@ -9,12 +11,12 @@ docker run -dt --name vroom \
     --net host \  # or set the container name as host in config.yml and use --port 3000:3000 instead, see below
     -v $PWD/conf:/conf \ # mapped volume for config & log
     -e VROOM_ROUTER=osrm \ # routing layer: osrm, valhalla or ors
-    vroomvrp/vroom-docker:v1.13.0
+    ghcr.iovroom-project/vroom-docker:v1.13.0
 ```
 
 If you want to build the image yourself, run a
 
-`docker build -t vroomvrp/vroom-docker:v1.13.0 --build-arg VROOM_RELEASE=v1.13.0 --build-arg VROOM_EXPRESS_RELEASE=v0.11.0 .`
+`docker build -t ghcr.iovroom-project/vroom-docker:v1.13.0 --build-arg VROOM_RELEASE=v1.13.0 --build-arg VROOM_EXPRESS_RELEASE=v0.11.0 .`
 
 > **Note**, you should have access to a self-hosted instance of OSRM, Valhalla or OpenRouteService for the routing server.
 


### PR DESCRIPTION
Also:
- builds `latest` twice a month and on master pushes, making our own versioning redundant
- tries out layer caching to accelerate image builds

fixes #68 
fixes #72 