### PR TITLE
Fix docker FromAsCasing warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,17 @@
-FROM debian:trixie-slim as builder
+FROM debian:trixie-slim AS builder
 LABEL maintainer=nils@gis-ops.com
 
 WORKDIR /
 
 RUN echo "Updating apt-get and installing dependencies..." && \
-  apt-get -y update > /dev/null && apt-get -y install > /dev/null \
-  git-core \
-  build-essential \
-	g++ \
-  libssl-dev \
-	libasio-dev \
-  libglpk-dev \
-	pkg-config
+    apt-get -y update > /dev/null && apt-get -y install > /dev/null \
+    git-core \
+    build-essential \
+    g++ \
+    libssl-dev \
+    libasio-dev \
+    libglpk-dev \
+    pkg-config
 
 ARG VROOM_EXPRESS_RELEASE=master
 
@@ -22,12 +22,11 @@ RUN echo "Cloning and installing vroom-express release/branch ${VROOM_EXPRESS_RE
 ARG VROOM_RELEASE=master
 
 RUN echo "Cloning and installing vroom release/branch ${VROOM_RELEASE}..." && \
-    git clone --branch $VROOM_RELEASE  --single-branch --recurse-submodules https://github.com/VROOM-Project/vroom.git && \
+    git clone --branch $VROOM_RELEASE --single-branch --recurse-submodules https://github.com/VROOM-Project/vroom.git && \
     cd vroom && \
     make -C /vroom/src -j$(nproc)
 
-
-FROM node:20-bookworm-slim as runstage
+FROM node:20-bookworm-slim AS runstage
 
 COPY --from=builder /vroom-express/. /vroom-express
 COPY --from=builder /vroom/bin/vroom /usr/local/bin
@@ -36,10 +35,10 @@ WORKDIR /vroom-express
 
 RUN apt-get update > /dev/null && \
     apt-get install -y --no-install-recommends \
-      libssl3 \
-      curl \
-      libglpk40 \
-      > /dev/null && \
+        libssl3 \
+        curl \
+        libglpk40 \
+        > /dev/null && \
     rm -rf /var/lib/apt/lists/* && \
     # Install vroom-express
     npm config set loglevel error && \
@@ -49,8 +48,8 @@ RUN apt-get update > /dev/null && \
 
 #Upgrade glibc
 RUN echo "deb http://ftp.debian.org/debian trixie main" >> /etc/apt/sources.list && \
-  apt-get update > /dev/null && \
-  apt-get -t trixie install libc6 libc6-dev libc6-dbg libstdc++6 libgcc-s1 libzstd1 -y
+    apt-get update > /dev/null && \
+    apt-get -t trixie install libc6 libc6-dev libc6-dbg libstdc++6 libgcc-s1 libzstd1 -y
 
 COPY ./docker-entrypoint.sh /docker-entrypoint.sh
 ENV VROOM_DOCKER=osrm \


### PR DESCRIPTION
Fixes FromAsCasing warning
https://docs.docker.com/reference/build-checks/from-as-casing/

> 2 warnings found (use docker --debug to expand):
 \- FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 30)
 \- FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
